### PR TITLE
fix interactive target placement

### DIFF
--- a/bccd/backend/Target.py
+++ b/bccd/backend/Target.py
@@ -1093,10 +1093,10 @@ class DraggablePoint:
     def set_xdata(self, x):
         """Set x coordinate"""
         for pt in self.points:
-            pt.set_xdata(x)    
+            pt.set_xdata([x])    
             
     # ======================================================================= #
     def set_ydata(self, y):
         """Set y coordinate"""
         for pt in self.points:
-            pt.set_ydata(y)
+            pt.set_ydata([y])


### PR DESCRIPTION
This patch fixes the ability to interactively place the target position. Without it, a runtime error is raised:

```python
  File "/usr/lib64/python3.13/site-packages/matplotlib/lines.py", line 1289, in set_xdata
    raise RuntimeError('x must be a sequence')
RuntimeError: x must be a sequence
```